### PR TITLE
Fix `mmm-insert-region' to not abort loop too soon

### DIFF
--- a/mmm-cmds.el
+++ b/mmm-cmds.el
@@ -357,9 +357,7 @@ including global classes."
         ;; If we have a group class, recurse.
         if (plist-get class :classes)
            if (mmm-get-insertion-spec key it)
-              return it
-           else
-              return nil))
+              return it))
 
 ;;}}}
 ;;{{{ Help on Insertion


### PR DESCRIPTION
Looping in spec definitions for insertion shortcuts was broken.

For example, with my setup (https://github.com/dgutov/dot-emacs/blob/master/mmm.el) "C-c % c" worked, but "C-c % j" did nothing.
