### PR TITLE
Make js-mode subregion fontification work

### DIFF
--- a/mmm-vars.el
+++ b/mmm-vars.el
@@ -289,6 +289,10 @@
 	 comment-end 
 	 comment-start 
 	 comment-start-skip))
+    ,@(mapcar
+       (lambda (var) (list var nil '(js-mode)))
+       '(js--quick-match-re
+         js--quick-match-re-func))
     ;; Skeleton insertion
     skeleton-transformation
     ;; Abbrev mode


### PR DESCRIPTION
These vars are set only once, during mode initialization, and they are used in `js--font-lock-keywords`.

The backtraces look like this:

```
Debugger entered--Lisp error: (wrong-type-argument stringp nil)
  re-search-forward(nil nil t)
  js--ensure-cache(10223)
  js--class-decl-matcher(10223)
  font-lock-fontify-keywords-region(10022 10223 nil)
  font-lock-default-fontify-region(10022 10223 nil)
  funcall(font-lock-default-fontify-region 10022 10223 nil)
  (lambda (reg) (goto-char (car reg)) (mmm-set-current-submode mode) (mmm-set-local-variables mode) (funcall func (car reg) (cadr reg) nil) (mmm-save-changed-local-variables mmm-current-overlay mmm-current-submode))((10022 10223))
  mapc((lambda (reg) (goto-char (car reg)) (mmm-set-current-submode mode) (mmm-set-local-variables mode) (funcall func (car reg) (cadr reg) nil) (mmm-save-changed-local-variables mmm-current-overlay mmm-current-submode)) ((10022 10223)))
  (let ((func (get mode (quote mmm-fontify-region-function))) font-lock-extend-region-functions) (mapc (function (lambda (reg) (goto-char (car reg)) (mmm-set-current-submode mode) (mmm-set-local-variables mode) (funcall func (car reg) (cadr reg) nil) (mmm-save-changed-local-variables mmm-current-overlay mmm-current-submode))) regions))
  (save-excursion (let ((func (get mode (quote mmm-fontify-region-function))) font-lock-extend-region-functions) (mapc (function (lambda (reg) (goto-char (car reg)) (mmm-set-current-submode mode) (mmm-set-local-variables mode) (funcall func (car reg) (cadr reg) nil) (mmm-save-changed-local-variables mmm-current-overlay mmm-current-submode))) regions)))
  mmm-fontify-region-list(js-mode ((10022 10223)))
...
```

I'm kind of surprised nobody has brought up this problem before here.
