### PR TITLE
Couple of more cc-mode variables added

### DIFF
--- a/mmm-vars.el
+++ b/mmm-vars.el
@@ -211,6 +211,7 @@
 	 c-label-minimum-indentation
 	 c-lambda-kwds
 	 c-literal-start-regexp 
+	 c-macro-with-semi-re
          c-nonlabel-token-key
 	 c-nonsymbol-chars 
 	 c-nonsymbol-token-regexp
@@ -272,6 +273,7 @@
 	 c-type-prefix-key 
          c-prefix-spec-kwds-re
          c-typedef-key
+	 c-typedef-decl-key
 	 comment-end 
 	 comment-start 
 	 comment-start-skip))


### PR DESCRIPTION
In addition to the ones that dgutov already added (in pull request https://github.com/purcell/mmm-mode/pull/16), this commit adds two more.

For background, see http://stackoverflow.com/questions/14220577/mmm-mode-implementing-c-mode-as-a-submode

Thanks.
