### PR TITLE
Define mmm-indent-line-function and its default value

### DIFF
--- a/mmm-erb.el
+++ b/mmm-erb.el
@@ -109,19 +109,10 @@
                  (?= ejs-expression nil @ "<%=" @ " " _ " " @ "%>" @))
         :creation-hook mmm-erb-mark-as-special)))
 
-(pushnew '(indent-line-function buffer) mmm-save-local-variables)
-
 ;;;###autoload
 (define-derived-mode html-erb-mode html-mode "ERB-HTML"
   (setq sgml-unclosed-tags nil) ; Simplifies indentation logic.
-  (add-hook 'mmm-html-erb-mode-hook 'mmm-erb-process-submode nil t)
-  (add-hook 'mmm-ruby-mode-submode-hook 'mmm-erb-process-submode nil t)
-  (add-hook 'mmm-css-mode-submode-hook 'mmm-erb-process-submode nil t)
-  (add-hook 'mmm-js-mode-submode-hook 'mmm-erb-process-submode nil t))
-
-(defun mmm-erb-process-submode ()
-  "Hook function to run after primary or submode major mode function."
-  (setq indent-line-function 'mmm-erb-indent-line))
+  (set (make-local-variable 'mmm-indent-line-function) 'mmm-erb-indent-line))
 
 (defun mmm-erb-mark-as-special ()
   "Hook function to run in ERB and EJS tag regions."
@@ -245,7 +236,7 @@
         ((re-search-forward " *{ *" limit t) 'open)))
 
 (defun mmm-erb-orig-indent-function (mode)
-  (cadr (assoc 'indent-line-function (get mode 'mmm-local-variables))))
+  (get mode 'mmm-indent-line-function))
 
 (defvar mmm-erb-offset-var-alist
   '((html-erb-mode . sgml-basic-offset)
@@ -257,9 +248,7 @@
 
 ;;;###autoload
 (define-derived-mode nxml-web-mode nxml-mode "nXML-Web"
-  (add-hook 'mmm-nxml-web-mode-hook 'mmm-erb-process-submode nil t)
-  (add-hook 'mmm-css-mode-submode-hook 'mmm-erb-process-submode nil t)
-  (add-hook 'mmm-js-mode-submode-hook 'mmm-erb-process-submode nil t))
+  (set (make-local-variable 'mmm-indent-line-function) 'mmm-erb-indent-line))
 
 (provide 'mmm-erb)
 

--- a/mmm-mode.el
+++ b/mmm-mode.el
@@ -117,17 +117,17 @@ over certain regions.  The submode regions are usually highlighted by
 a background color for ease of recognition.  While the point is in a
 submode region, the following changes \(are supposed to) occur:
 
-1. The local keymap is that of the submode.
+1. The local keymap and the syntax table are that of the submode.
 2. The mode line changes to show what submode region is active.
 3. The major mode menu and mouse popup menu are that of the submode.
 4. Some local variables of the submode shadow the default mode's.
-5. The syntax table and indentation are those of the submode.
-6. Font-lock fontifies correctly for the submode.
+5. Font-lock fontifies correctly for the submode.
+6. Indentation function dispatches to the appropriate submode.
 
 For further information, including installation and configuration
 instructions, see the Info file mmm.info which is included with the
 distribution of MMM Mode.  Many of MMM's configuration variables are
-available through M-x customize under Programming | Tools | Mmm."
+available through M-x customize-group RET mmm."
   (interactive "P")
   (if (if arg (> (prefix-numeric-value arg) 0) (not mmm-mode))
       (mmm-mode-on)
@@ -168,6 +168,7 @@ available through M-x customize under Programming | Tools | Mmm."
           'mmm-beginning-of-syntax)
      (set (make-local-variable 'syntax-propertize-function)
           'mmm-syntax-propertize-function)
+     (set (make-local-variable 'indent-line-function) mmm-indent-line-function)
      (setq mmm-mode t)
      (condition-case err
          (mmm-apply-all)

--- a/mmm-region.el
+++ b/mmm-region.el
@@ -511,7 +511,8 @@ is non-nil, don't quit if the info is already there."
                          font-lock-beginning-of-syntax-function))
                 (put mode 'mmm-syntax-propertize-function
                      (and (boundp 'syntax-propertize-function)
-                          syntax-propertize-function)))
+                          syntax-propertize-function))
+                (put mode 'mmm-indent-line-function indent-line-function))
               ;; Get variables
               (setq global-vars (mmm-get-locals 'global)
                     buffer-vars (mmm-get-locals 'buffer)
@@ -821,7 +822,24 @@ of the REGIONS covers START to STOP."
       (mmm-set-local-variables saved-mode saved-ovl))))
 
 ;;}}}
+;;{{{ Indentation
 
+(defvar mmm-indent-line-function 'mmm-indent-line
+  "The function to call to indent inside a primary mode region.
+This will be the value of `indent-line-function' for the whole
+buffer. It's supposed to delegate to the appropriate submode's
+indentation function. See `mmm-indent-line' as the starting point.")
+
+(defun mmm-indent-line ()
+  (interactive)
+  (funcall
+    (save-excursion
+      (back-to-indentation)
+      (mmm-update-submode-region)
+      (get (or mmm-current-submode mmm-primary-mode)
+           'mmm-indent-line-function))))
+
+;;}}}
 (provide 'mmm-region)
 
 ;;; mmm-region.el ends here

--- a/mmm-vars.el
+++ b/mmm-vars.el
@@ -131,7 +131,6 @@
     font-lock-syntax-table
     font-lock-mark-block-function       ; Override this?
     font-lock-syntactic-keywords
-    indent-line-function
     parse-sexp-ignore-comments  ; Fixes indentation in PHP-mode?
     ;; Can be different in different buffers
     (c-basic-offset


### PR DESCRIPTION
See the commit.

Drawbacks:
1) `mmm-update-submode-region` will make default indentation a bit slower.
2) If some people preferred to indent the closing line of a multiline subregion by first navigating to the eol (where it's back to the primary mode), it won't work now. That approach is definitely flawed, though.

Thoughts?
