### PR TITLE
Mode transition hooks

### DIFF
--- a/mmm-mode.el
+++ b/mmm-mode.el
@@ -123,6 +123,16 @@ submode region, the following changes \(are supposed to) occur:
 4. Some local variables of the submode shadow the default mode's.
 5. Font-lock fontifies correctly for the submode.
 6. Indentation function dispatches to the appropriate submode.
+7. User-specified hooks run when the point enters or exits a submode.
+
+The user may specify a number of hooks which may run when the point
+transitions between submodes, or between the primary mode and a
+submode. When a major mode is entered, the hook mmm-x-enter-hook is
+run, where x is the name of the major mode. When a major mode is
+left, the hook mmm-y-exit-hook is run, where y is the name of the
+major mode. Users may also specify hooks with names of the form
+mmm-x-y-hook which are run when the point leaves a mode named x,
+and enters a mode named y.
 
 For further information, including installation and configuration
 instructions, see the Info file mmm.info which is included with the

--- a/mmm-region.el
+++ b/mmm-region.el
@@ -545,10 +545,14 @@ different keymaps, syntax tables, local variables, etc. for submodes."
   (when (mmm-update-current-submode)
     (mmm-save-changed-local-variables mmm-previous-submode
                                       mmm-previous-overlay)
-    (let ((mode (or mmm-current-submode mmm-primary-mode)))
-      (mmm-update-mode-info mode)
-      (mmm-set-local-variables mode mmm-current-overlay)
-      (mmm-enable-font-lock mode))
+    (let ((new-mode (or mmm-current-submode mmm-primary-mode))
+          (old-mode (or mmm-previous-submode mmm-primary-mode)))
+      (mmm-run-constructed-hook old-mode new-mode)
+      (mmm-run-constructed-hook old-mode "exit")
+      (mmm-run-constructed-hook new-mode "enter")
+      (mmm-update-mode-info new-mode)
+      (mmm-set-local-variables new-mode mmm-current-overlay)
+      (mmm-enable-font-lock new-mode))
     (mmm-set-mode-line)
     (dolist (func (if mmm-current-overlay
 		      (overlay-get mmm-current-overlay 'entry-hook)


### PR DESCRIPTION
I'm not 100% sure if mmm-mode allows you to do this already, but I couldn't 
find anything. This allows the user to set hooks to run when submodes are
entered and left. It also allows the user to specify hooks for specific mode-to-mode
transitions.

I'm also not 100% sure where this should be documented; perhaps in 
`mmm-mode-hook`?

An example below:

```elisp
(setq mmm-js-mode-exit-hook (lambda () (message "Run when leaving js mode")))
(setq mmm-js-mode-enter-hook (lambda () (message "Run when entering js mode")))
(setq mmm-vue-mode-js-mode-hook (lambda () (message "Run when moving From vue to js")))
(setq mmm-js-mode-vue-mode-hook (lambda () (message "Run when moving From js to vue")))
```