### PR TITLE
Add function for narrowed indentation

### DIFF
--- a/mmm-region.el
+++ b/mmm-region.el
@@ -871,6 +871,18 @@ This will be the value of `indent-line-function' for the whole
 buffer. It's supposed to delegate to the appropriate submode's
 indentation function. See `mmm-indent-line' as the starting point.")
 
+(defun mmm-indent-line-narrowed ()
+  "An indent function which works on modes which don't play well with mmm-mode.
+Calls `mmm-indent-line' internally, but narrows the buffer before indenting to
+appease modes which rely on constructs like (point-min) to indent."
+  (interactive)
+  (if mmm-current-overlay
+      (save-restriction
+        (narrow-to-region (overlay-start mmm-current-overlay)
+                          (overlay-end mmm-current-overlay))
+        (mmm-indent-line))
+    (mmm-indent-line)))
+
 (defun mmm-indent-line ()
   (interactive)
   (funcall

--- a/mmm-region.el
+++ b/mmm-region.el
@@ -872,8 +872,8 @@ buffer. It's supposed to delegate to the appropriate submode's
 indentation function. See `mmm-indent-line' as the starting point.")
 
 (defun mmm-indent-line-narrowed ()
-  "An indent function which works on modes which don't play well with mmm-mode.
-Works like `mmm-indent-line' , but narrows the buffer before indenting to
+  "An indent function which works on some modes where `mmm-indent-line' doesn't.
+Works like `mmm-indent-line', but narrows the buffer before indenting to
 appease modes which rely on constructs like (point-min) to indent."
   (interactive)
   (funcall
@@ -896,7 +896,7 @@ appease modes which rely on constructs like (point-min) to indent."
 (defun mmm-indent-line ()
   (interactive)
   (funcall
-    (save-excursion
+   (save-excursion
       (back-to-indentation)
       (mmm-update-submode-region)
       (get


### PR DESCRIPTION
Sometimes, modes rely on functions like (point-min) or overstep their region
when attempting to indent a line. This can cause issues like
https://github.com/AdamNiederer/vue-mode/issues/50

This function narrows the buffer before indenting, preventing any issues which
might arise from reliance on having one's own buffer.

This doesn't change any defaults, but I figured some other mmm-mode derivatives
could make use of this function.