### PR TITLE
Namespace cl functions

### DIFF
--- a/mmm-compat.el
+++ b/mmm-compat.el
@@ -115,6 +115,16 @@ This text should not be modified."
        (insert-buffer ,buffer)
        (current-buffer))))
 
+;;; {{{ Emacs < 26 requires namespaced CL functions
+
+(when (< emacs-major-version 26)
+  (require 'cl-lib)
+  (defalias 'mapcan 'cl-mapcan)
+  (defalias 'cadddr 'cl-cadddr)
+  (defalias 'caddr ' cl-caddr))
+
+;;; }}}
+
 (provide 'mmm-compat)
 
 ;;; mmm-compat.el ends here

--- a/mmm-compat.el
+++ b/mmm-compat.el
@@ -115,15 +115,16 @@ This text should not be modified."
        (insert-buffer ,buffer)
        (current-buffer))))
 
-;;; {{{ Emacs < 26 requires namespaced CL functions
+;;}}}
+;;{{{ Emacs < 26 requires namespaced CL functions
 
 (when (< emacs-major-version 26)
   (require 'cl-lib)
-  (defalias 'mapcan 'cl-mapcan)
-  (defalias 'cadddr 'cl-cadddr)
-  (defalias 'caddr ' cl-caddr))
+  (defalias 'mmm-mapcan 'cl-mapcan)
+  (defalias 'mmm-cadddr 'cl-cadddr)
+  (defalias 'mmm-caddr ' cl-caddr))
 
-;;; }}}
+;;}}}
 
 (provide 'mmm-compat)
 

--- a/mmm-region.el
+++ b/mmm-region.el
@@ -849,8 +849,8 @@ calls each respective submode's `syntax-propertize-function'."
         (mapc (lambda (elt)
                   (let* ((mode (car elt))
                          (func (get mode 'mmm-syntax-propertize-function))
-                         (beg (cadr elt)) (end (caddr elt))
-                         (ovl (cadddr elt))
+                         (beg (cadr elt)) (end (mmm-caddr elt))
+                         (ovl (mmm-cadddr elt))
                          ;; FIXME: Messing with syntax-ppss-* vars should not
                          ;; be needed any more in Emacs≥26.
                          syntax-ppss-cache

--- a/mmm-region.el
+++ b/mmm-region.el
@@ -576,7 +576,7 @@ different keymaps, syntax tables, local variables, etc. for submodes."
   "Filter `mmm-save-local-variables' to match TYPE and MODE.
 Return a list \(VAR ...).  In some cases, VAR will be a cons cell
 \(GETTER . SETTER) -- see `mmm-save-local-variables'."
-  (mapcan #'(lambda (element)
+  (cl-mapcan #'(lambda (element)
               (and (if (and (consp element)
                             (cdr element)
                             (cadr element))
@@ -584,10 +584,10 @@ Return a list \(VAR ...).  In some cases, VAR will be a cons cell
                      (eq type 'global))
                    (if (and (consp element)
                             (cddr element)
-                            (not (eq (caddr element) t)))
-                       (if (functionp (caddr element))
-                           (funcall (caddr element))
-                         (member mode (caddr element)))
+                            (not (eq (cl-caddr element) t)))
+                       (if (functionp (cl-caddr element))
+                           (funcall (cl-caddr element))
+                         (member mode (cl-caddr element)))
                      t)
                    (list (if (consp element) (car element) element))))
           mmm-save-local-variables))
@@ -596,7 +596,7 @@ Return a list \(VAR ...).  In some cases, VAR will be a cons cell
   "Get the local variables and values for TYPE from this buffer.
 Return \((VAR VALUE) ...).  In some cases, VAR will be of the form
 \(GETTER . SETTER) -- see `mmm-save-local-variables'."
-  (mapcan #'(lambda (var)
+  (cl-mapcan #'(lambda (var)
               (if (consp var)
                   `((,var ,(funcall (car var))))
                 (and (boundp var)
@@ -724,7 +724,7 @@ region and mode for the previous position."
   "Return a list of all submode-change positions from START to STOP.
 The list is sorted in order of increasing buffer position."
   (let ((changes (sort (cl-remove-duplicates
-                        (mapcan (lambda (ovl)
+                        (cl-mapcan (lambda (ovl)
                                     `(,(overlay-start ovl)
                                       ,(overlay-end ovl)))
                                 (mmm-overlays-overlapping start stop)))
@@ -849,8 +849,8 @@ calls each respective submode's `syntax-propertize-function'."
         (mapc (lambda (elt)
                   (let* ((mode (car elt))
                          (func (get mode 'mmm-syntax-propertize-function))
-                         (beg (cadr elt)) (end (caddr elt))
-                         (ovl (cadddr elt))
+                         (beg (cadr elt)) (end (cl-caddr elt))
+                         (ovl (cl-cadddr elt))
                          ;; FIXME: Messing with syntax-ppss-* vars should not
                          ;; be needed any more in Emacs≥26.
                          syntax-ppss-cache

--- a/mmm-region.el
+++ b/mmm-region.el
@@ -576,7 +576,7 @@ different keymaps, syntax tables, local variables, etc. for submodes."
   "Filter `mmm-save-local-variables' to match TYPE and MODE.
 Return a list \(VAR ...).  In some cases, VAR will be a cons cell
 \(GETTER . SETTER) -- see `mmm-save-local-variables'."
-  (mapcan #'(lambda (element)
+  (mmm-mapcan #'(lambda (element)
               (and (if (and (consp element)
                             (cdr element)
                             (cadr element))
@@ -584,10 +584,10 @@ Return a list \(VAR ...).  In some cases, VAR will be a cons cell
                      (eq type 'global))
                    (if (and (consp element)
                             (cddr element)
-                            (not (eq (caddr element) t)))
-                       (if (functionp (caddr element))
-                           (funcall (caddr element))
-                         (member mode (caddr element)))
+                            (not (eq (mmm-caddr element) t)))
+                       (if (functionp (mmm-caddr element))
+                           (funcall (mmm-caddr element))
+                         (member mode (mmm-caddr element)))
                      t)
                    (list (if (consp element) (car element) element))))
           mmm-save-local-variables))
@@ -596,7 +596,7 @@ Return a list \(VAR ...).  In some cases, VAR will be a cons cell
   "Get the local variables and values for TYPE from this buffer.
 Return \((VAR VALUE) ...).  In some cases, VAR will be of the form
 \(GETTER . SETTER) -- see `mmm-save-local-variables'."
-  (mapcan #'(lambda (var)
+  (mmm-mapcan #'(lambda (var)
               (if (consp var)
                   `((,var ,(funcall (car var))))
                 (and (boundp var)
@@ -724,7 +724,7 @@ region and mode for the previous position."
   "Return a list of all submode-change positions from START to STOP.
 The list is sorted in order of increasing buffer position."
   (let ((changes (sort (cl-remove-duplicates
-                        (mapcan (lambda (ovl)
+                        (mmm-mapcan (lambda (ovl)
                                     `(,(overlay-start ovl)
                                       ,(overlay-end ovl)))
                                 (mmm-overlays-overlapping start stop)))

--- a/mmm-region.el
+++ b/mmm-region.el
@@ -576,7 +576,7 @@ different keymaps, syntax tables, local variables, etc. for submodes."
   "Filter `mmm-save-local-variables' to match TYPE and MODE.
 Return a list \(VAR ...).  In some cases, VAR will be a cons cell
 \(GETTER . SETTER) -- see `mmm-save-local-variables'."
-  (cl-mapcan #'(lambda (element)
+  (mapcan #'(lambda (element)
               (and (if (and (consp element)
                             (cdr element)
                             (cadr element))
@@ -584,10 +584,10 @@ Return a list \(VAR ...).  In some cases, VAR will be a cons cell
                      (eq type 'global))
                    (if (and (consp element)
                             (cddr element)
-                            (not (eq (cl-caddr element) t)))
-                       (if (functionp (cl-caddr element))
-                           (funcall (cl-caddr element))
-                         (member mode (cl-caddr element)))
+                            (not (eq (caddr element) t)))
+                       (if (functionp (caddr element))
+                           (funcall (caddr element))
+                         (member mode (caddr element)))
                      t)
                    (list (if (consp element) (car element) element))))
           mmm-save-local-variables))
@@ -596,7 +596,7 @@ Return a list \(VAR ...).  In some cases, VAR will be a cons cell
   "Get the local variables and values for TYPE from this buffer.
 Return \((VAR VALUE) ...).  In some cases, VAR will be of the form
 \(GETTER . SETTER) -- see `mmm-save-local-variables'."
-  (cl-mapcan #'(lambda (var)
+  (mapcan #'(lambda (var)
               (if (consp var)
                   `((,var ,(funcall (car var))))
                 (and (boundp var)
@@ -724,7 +724,7 @@ region and mode for the previous position."
   "Return a list of all submode-change positions from START to STOP.
 The list is sorted in order of increasing buffer position."
   (let ((changes (sort (cl-remove-duplicates
-                        (cl-mapcan (lambda (ovl)
+                        (mapcan (lambda (ovl)
                                     `(,(overlay-start ovl)
                                       ,(overlay-end ovl)))
                                 (mmm-overlays-overlapping start stop)))
@@ -849,8 +849,8 @@ calls each respective submode's `syntax-propertize-function'."
         (mapc (lambda (elt)
                   (let* ((mode (car elt))
                          (func (get mode 'mmm-syntax-propertize-function))
-                         (beg (cadr elt)) (end (cl-caddr elt))
-                         (ovl (cl-cadddr elt))
+                         (beg (cadr elt)) (end (caddr elt))
+                         (ovl (cadddr elt))
                          ;; FIXME: Messing with syntax-ppss-* vars should not
                          ;; be needed any more in Emacs≥26.
                          syntax-ppss-cache


### PR DESCRIPTION
`mmm-mode` 0.5.5 broke `vue-mode` (and introduced some byte-compilation warnings) by introducing un-namespaced versions of `cl-mapcan`, `cl-caddr`, and `cl-cadddr` into `mmm-region.el`. This reverts the change.

ref: https://github.com/AdamNiederer/vue-mode/issues/73