### PR TITLE
Fix make failed with texinfo version 6.7

### DIFF
--- a/mmm.texinfo
+++ b/mmm.texinfo
@@ -1,5 +1,6 @@
 \input texinfo
 @c %**start of header
+@documentencoding utf-8
 @setfilename mmm.info
 @settitle MMM Mode Manual
 @c %**end of header


### PR DESCRIPTION
make command failed if you build with texinfo 6.7.
It causes the following error:

```
❯ make
restore=: && backupdir=".am$$" && \
am__cwd=`pwd` && CDPATH="${ZSH_VERSION+.}:" && cd . && \
rm -rf $backupdir && mkdir $backupdir && \
if (makeinfo --version) >/dev/null 2>&1; then \
  for f in mmm.info mmm.info-[0-9] mmm.info-[0-9][0-9] mmm.i[0-9] mmm.i[0-9][0-9]; do \
    if test -f $f; then mv $f $backupdir; restore=mv; else :; fi; \
  done; \
else :; fi && \
cd "$am__cwd"; \
if makeinfo   -I . \
 -o mmm.info mmm.texinfo; \
then \
  rc=0; \
  CDPATH="${ZSH_VERSION+.}:" && cd .; \
else \
  rc=$?; \
  CDPATH="${ZSH_VERSION+.}:" && cd . && \
  $restore $backupdir/* `echo "./mmm.info" | sed 's|[^/]*$||'`; \
fi; \
rm -rf $backupdir; exit $rc
utf8 "\xF8" does not map to Unicode at /usr/share/texinfo/Texinfo/ParserNonXS.pm line 1796, <FH> line 1448.
Malformed UTF-8 character: \xf8\x72\x6c\x79\x6b (unexpected non-continuation byte 0x72, immediately after start byte 0xf8; need 5 bytes, got 1) in pattern match (m//) at /usr/share/texinfo/Texinfo/ParserNonXS.pm line 3364.
Malformed UTF-8 character (fatal) at /usr/share/texinfo/Texinfo/ParserNonXS.pm line 3364.
make: *** [Makefile:364: mmm.info] Error 25
```

To fix this issue, it seems enough just adding `@documentencoding` in texinfo file.