### PR TITLE
Improved handling of shell here docs

### DIFF
--- a/mmm-auto.el
+++ b/mmm-auto.el
@@ -1,6 +1,6 @@
 ;;; mmm-auto.el --- loading and enabling MMM Mode automatically
 
-;; Copyright (C) 2000-2004,  2012, 2013, 2018  Free Software Foundation, Inc.
+;; Copyright (C) 2000-2004,  2012, 2013, 2018, 2022  Free Software Foundation, Inc.
 
 ;; Author: Michael Abraham Shulman <mas@kurukshetra.cjb.net>
 
@@ -26,7 +26,7 @@
 ;;; Commentary:
 
 ;; This file contains functions and hooks to load and enable MMM Mode
-;; automatically. It sets up autoloads for the main MMM Mode functions
+;; automatically.  It sets up autoloads for the main MMM Mode functions
 ;; and interactive commands, and also sets up MMM Global Mode.
 
 ;;{{{ Comments on MMM Global Mode
@@ -44,15 +44,15 @@
 ;; FIXME: There's now after-change-major-mode-hook which should DTRT.
 
 ;; In order to do this magic, we rely on the fact that there *is* a
-;; hook that all major modes run when *beginning* their work. They
+;; hook that all major modes run when *beginning* their work.  They
 ;; call `kill-all-local-variables' (unless they are broken), which in
 ;; turn runs `change-major-mode-hook'.  So we add a function to *that*
 ;; hook which saves the current buffer and temporarily adds a function
 ;; to `post-command-hook' which processes that buffer.
 
 ;; Actually, in the interests of generality, what that function does
-;; is run the hook `mmm-major-mode-hook'. Our desired function
-;; `mmm-mode-on-maybe' is then added to that hook. This way, if the
+;; is run the hook `mmm-major-mode-hook'.  Our desired function
+;; `mmm-mode-on-maybe' is then added to that hook.  This way, if the
 ;; user wants to run something else on every major mode, they can just
 ;; add it to `mmm-major-mode-hook' and take advantage of this hack.
 
@@ -70,6 +70,7 @@
     (html-css "mmm-sample" nil)
     (html-js "mmm-sample" nil)
     (here-doc "mmm-sample" nil)
+    (sh-here-doc "mmm-sample" nil)
     (embperl "mmm-sample" nil)
     (eperl "mmm-sample" nil)
     (jsp "mmm-sample" nil)

--- a/mmm-mode.el
+++ b/mmm-mode.el
@@ -9,7 +9,7 @@
 ;; URL: https://github.com/purcell/mmm-mode
 ;; Keywords: convenience, faces, languages, tools
 ;; Version: 0.5.8
-;; Package-Requires: ((cl-lib "0.2"))
+;; Package-Requires: ((emacs "25.1") (cl-lib "0.2"))
 
 ;;{{{ GPL
 

--- a/mmm-sample.el
+++ b/mmm-sample.el
@@ -26,7 +26,7 @@
 ;;; Commentary:
 
 ;; This file contains several sample submode classes for use with MMM
-;; Mode. For a more detailed, advanced example, see `mmm-mason.el'.
+;; Mode.  For a more detailed, advanced example, see `mmm-mason.el'.
 
 ;; In order to use any of classes defined here, just require `mmm-auto' and
 ;; add the respective (major mode -> class <- file extension) associations
@@ -177,6 +177,48 @@ First match of [a-zA-Z_-]+ is used as the submode marker."
     :insert ((?d here-doc "Here-document Name: " @ "<<" str _ "\n"
                  @ "\n" @ str "\n" @))
     )))
+
+(defun mmm-sh-here-doc-get-mode (front-string)
+  "Find the mode for a shell here-doc starting with FRONT-STRING.
+The matching is based on the word used as the here-document
+delimiter, the word following <<.
+Use `mmm-get-lang-mode' to find the submode."
+  (mmm-get-lang-mode front-string "<<-?\\(['\"]?\\)\\([-a-zA-Z0-9_]+\\)\\1" 2))
+
+;; HEREDOC for shell scripts following the POSIX definition.  It is
+;; defined in two classes that are then grouped into the class
+;; sh-here-doc
+;; Define some regex-parts that are reused a lot.
+;; START is the '<<' sequence
+(rx-let ((start (sequence (or line-start (not "<")) "<<"))
+		 ;; DELIM is supposed to be a WORD, which is a complicated definition.
+		 ;; It may be quoted with ', ", or `
+         (delim (sequence (group-n 2 (optional (any ?' ?\" ?`)))
+                          (group-n 1
+                            (char "_a-zA-Z0-9")
+                            (one-or-more (char "-" "_a-zA-Z0-9")))
+                          (backref 2))))
+  ;; some repeated class properties
+  (let ((common-props '(:front-offset (end-of-line 1)
+                        :save-matches t
+                        :delimiter-mode nil
+                        :match-submode mmm-sh-here-doc-get-mode)))
+    (mmm-add-classes
+     `((sh-here-doc-unindented
+        :front ,(rx start delim)
+        :back ,(rx line-start "~1" line-end)
+        ,@common-props
+        :insert ((?d here-doc "Here-document Name: " @ "<<" str _ "\n"
+                     @ "\n" @ str "\n" @)))
+       (sh-here-doc-indented
+        :front ,(rx start "-" delim)
+        :back ,(rx line-start (zero-or-more "\t") "~1" line-end)
+        ,@common-props
+        :insert ((?D here-doc "Here-document Name: " @ "<<-" str _ "\n"
+                     @ "\n" @ str "\n" @)))
+       (sh-here-doc ; define a grouping class
+        :classes (sh-here-doc-unindented sh-here-doc-indented))))))
+
 
 ;;}}}
 ;;{{{ Embperl

--- a/mmm-sample.el
+++ b/mmm-sample.el
@@ -1,6 +1,6 @@
 ;;; mmm-sample.el --- Sample MMM submode classes
 
-;; Copyright (C) 2000-2004, 2012-2015, 2018  Free Software Foundation, Inc.
+;; Copyright (C) 2000-2004, 2012-2015, 2018, 2022  Free Software Foundation, Inc.
 
 ;; Author: Michael Abraham Shulman <viritrilbia@gmail.com>
 
@@ -113,9 +113,21 @@ add elements to this alist.  Each element is \(REGEXP . MODE) where
 REGEXP is a regular expression matched against the here-document name
 and MODE is a major mode function symbol.")
 
-(defun mmm-here-doc-get-mode (string)
-  (string-match "[a-zA-Z_-]+" string)
-  (setq string (match-string 0 string))
+(defun mmm-get-lang-mode (string regex group)
+  "Find a suitable submode for STRING.
+If REGEX matches STRING, The matching is based on the match
+GROUP.
+
+The following ways to find a matching submode are tried in order:
+
+* Search `mmm-here-doc-mode-alist' for a mode.
+* Try the whole name, stopping at `mode' if present.
+* Try each word by itself (preference list)
+* Try each word with -mode tacked on
+* Try each pair of words with -mode tacked on
+  (w1 w2 w3) -> (w1w2-mode w2w3-mode w3-mode)"
+  (string-match regex string)
+  (setq string (match-string group string))
   (or (mmm-ensure-modename
        ;; First try the user override variable.
        (cl-some (lambda (pair)
@@ -148,6 +160,11 @@ and MODE is a major mode function symbol.")
             ;; name (perhaps minus `-mode') doesn't occur in the
             ;; here-document name, we can give up.
             (signal 'mmm-no-matching-submode nil)))))
+
+(defun mmm-here-doc-get-mode (string)
+  "Find a submode for STRING.
+First match of [a-zA-Z_-]+ is used as the submode marker."
+  (mmm-get-lang-mode string "\\([a-zA-Z_-]+\\)" 1))
 
 (mmm-add-classes
  '((here-doc

--- a/mmm.texi
+++ b/mmm.texi
@@ -1344,10 +1344,18 @@ print <<END_HTML;
 END_HTML
 @end example
 
-The @code{here-doc} submode class recognizes this syntax, and can even
-guess the correct submode to use in many cases.  For instance, it would
+The @code{here-doc} submode class supports the general case of
+here-documents while the @code{sh-here-doc} class has more specialized
+support for shell scripts.  They can both guess the correct submode to
+use based on the @dfn{delimiter} (@code{END_HTML} in the example)
+used.  For instance, it would
 put the above example in @code{html-mode}, noticing the string
-@samp{HTML} in the name of the here-document.  If you use less than
+@samp{HTML} in the delimiter of the here-document.  Generally speaking
+any language mode can be found if the language name is one of the
+words in delimiter, but be aware that the first word that matches will
+be used. The @code{mmm-major-mode-preferences} list is checked for any
+language mode preferences, as described in @ref{Preferred Modes}.  If
+you use less than
 evocative here-document names, or if the submode is recognized
 incorrectly for any other reason, you can tell it explicitly what
 submode to use.


### PR DESCRIPTION
Shell here docs has more options than what was supported by the `here-doc` `mmm-class`. 